### PR TITLE
Fixed the load order of metadata types so it doesnt get confused

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,14 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.0.0"
+version = "1.0.1"
 group= "com.tombenpotter.icarus" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Icarus"
 
 minecraft {
     version = "1.7.10-10.13.4.1492-1.7.10"
     runDir = "eclipse"
+    replace '@VERSION@', project.version
 }
 
 dependencies {

--- a/src/main/java/tombenpotter/icarus/Icarus.java
+++ b/src/main/java/tombenpotter/icarus/Icarus.java
@@ -20,7 +20,7 @@ public class Icarus {
 
     public static final String modid = "TIcarus";
     public static final String name = "Icarus";
-    public static final String version = "1.0.1";
+    public static final String version = "@VERSION@";
     public static final String texturePath = "icarus";
     public static final String channel = "Icarus";
     public static final String depend = "after:AWWayofTime;after:Thaumcraft;after:ThermalExpansion";

--- a/src/main/java/tombenpotter/icarus/common/IcarusItems.java
+++ b/src/main/java/tombenpotter/icarus/common/IcarusItems.java
@@ -60,13 +60,6 @@ public class IcarusItems {
             GameRegistry.addShapelessRecipe(new ItemStack(thaumiumWings), new ItemStack(singleWings, 1, 4), new ItemStack(singleWings, 1, 4));
         }
 
-        voidMetalWings = new ItemWingThaumcraft.ItemWingVoidMetal(ThaumcraftApi.armorMatVoid, new IcarusWing("VoidMetalWing", 768, 384, 0.7, 0.4, -0.1, -0.1, 0.75));
-        if (OreDictionary.doesOreNameExist("ingotVoid") && OreDictionary.doesOreNameExist("shardEntropy")) {
-            GameRegistry.registerItem(voidMetalWings, "ItemVoidMetalWings");
-            GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(singleWings, 1, 9), "XX ", "XYY", " XX", 'X', "ingotVoid", 'Y', "shardEntropy"));
-            GameRegistry.addShapelessRecipe(new ItemStack(voidMetalWings), new ItemStack(singleWings, 1, 9), new ItemStack(singleWings, 1, 9));
-        }
-
         bronzeWings = new ItemWing(ItemArmor.ArmorMaterial.IRON, new IcarusWing("BronzeWing", 384, 132, 0.5, 0.85, -0.2, -0.4, 0.5));
         if (OreDictionary.doesOreNameExist("ingotBronze")) {
             GameRegistry.registerItem(bronzeWings, "ItemBronzeWings");
@@ -93,6 +86,14 @@ public class IcarusItems {
             GameRegistry.registerItem(enderiumWings, "ItemEnderiumWings");
             GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(singleWings, 1, 8), "XX ", "XYY", " XX", 'X', "ingotEnderium", 'Y', ModItemGetter.resonantCapacitor));
             GameRegistry.addShapelessRecipe(new ItemStack(enderiumWings), new ItemStack(singleWings, 1, 8), new ItemStack(singleWings, 1, 8));
+        }
+
+        
+        voidMetalWings = new ItemWingThaumcraft.ItemWingVoidMetal(ThaumcraftApi.armorMatVoid, new IcarusWing("VoidMetalWing", 768, 384, 0.7, 0.4, -0.1, -0.1, 0.75));
+        if (OreDictionary.doesOreNameExist("ingotVoid") && OreDictionary.doesOreNameExist("shardEntropy")) {
+            GameRegistry.registerItem(voidMetalWings, "ItemVoidMetalWings");
+            GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(singleWings, 1, 9), "XX ", "XYY", " XX", 'X', "ingotVoid", 'Y', "shardEntropy"));
+            GameRegistry.addShapelessRecipe(new ItemStack(voidMetalWings), new ItemStack(singleWings, 1, 9), new ItemStack(singleWings, 1, 9));
         }
     }
 }


### PR DESCRIPTION
I fixed the issue I was previously having trying to trying to make wings and having the RF tier required to make it reduced by one level allowing you to make leadstone powered wings out of bronze, .electrum powered wings out of leadstone, and enderium power wings out of electrum. This was because the single item wing pairs were out of order while registering recipes. I added the version to the main jar that will be changed everytime its changed in the build.gradle for convienience. Hopefully this is a much cleaner approach that fixes the issue and doesn't mess up your metadata structure. ![](http://i.imgur.com/Zj19qEw.png), ![](http://i.imgur.com/ay1poeY.png), ![](http://i.imgur.com/KXuxzTD.png), ![](http://i.imgur.com/QOLwVgB.png) pictures taken in latest curse build. Pictures added after merged for documentation and clarity.

my bad!
mrammy
