### PR TITLE
Pull Request #30

### DIFF
--- a/src/main/java/tombenpotter/icarus/client/ClientEventHandler.java
+++ b/src/main/java/tombenpotter/icarus/client/ClientEventHandler.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderPlayerEvent;
@@ -48,15 +49,21 @@ public class ClientEventHandler {
     @SubscribeEvent
     public void renderPlayerWings(RenderPlayerEvent.Specials.Post event) {
         ItemStack stack = event.entityPlayer.inventory.armorInventory[2];
-        if (stack != null && stack.getItem() instanceof ItemWing) {
+        EntityPlayer player = event.entityPlayer;
+        if (stack != null && stack.getItem() instanceof ItemWing && player != null) {
             ItemWing itemWing = (ItemWing) stack.getItem();
+            Tessellator tesselator = Tessellator.instance;
+            float flap = event.entityPlayer.onGround ? 0 : (1.0F + (float) Math.cos(render() / 4.0F)) * 13.0F;
+
             GL11.glPushMatrix();
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             minecraft.renderEngine.bindTexture(new ResourceLocation(Icarus.texturePath + ":textures/items/wings/" + itemWing.getWing(stack).name + ".png"));
-            GL11.glTranslatef(0F, -0.3125F, 0.125F);
-            Tessellator tesselator = Tessellator.instance;
+            
+            if (player.isSneaking())
+                GL11.glRotatef(28.64789F, 1.0F, 0.0F, 0.0F);
 
-            float flap = event.entityPlayer.onGround ? 0 : (1.0F + (float) Math.cos(render() / 4.0F)) * 13.0F;
+            GL11.glTranslatef(0F, -0.3125F, 0.125F);
+            
 
             GL11.glPushMatrix();
             GL11.glRotatef(-20.0F, 0.0F, 1.0F, 0.0F);

--- a/src/main/java/tombenpotter/icarus/common/items/ItemWing.java
+++ b/src/main/java/tombenpotter/icarus/common/items/ItemWing.java
@@ -148,14 +148,12 @@ public class ItemWing extends ItemArmor implements IWingHUD {
     }
 
     public void handleTick(World world, EntityPlayer player, ItemStack stack) {
-        if (world.isRemote) {
-            if (stack.getItem() instanceof ISpecialWing) {
-                ISpecialWing specialWing = (ISpecialWing) stack.getItem();
-                if (!specialWing.canWingBeUsed(stack, player)) {
-                    return;
-                }
-                specialWing.onWingTick(stack, player);
+        if (stack.getItem() instanceof ISpecialWing) {
+            ISpecialWing specialWing = (ISpecialWing) stack.getItem();
+            if (!specialWing.canWingBeUsed(stack, player)) {
+                return;
             }
+           specialWing.onWingTick(stack, player);
         }
     }
 

--- a/src/main/java/tombenpotter/icarus/common/items/ItemWingAuraCascade.java
+++ b/src/main/java/tombenpotter/icarus/common/items/ItemWingAuraCascade.java
@@ -3,10 +3,13 @@ package tombenpotter.icarus.common.items;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.common.ISpecialArmor;
 import tombenpotter.icarus.ConfigHandler;
 import tombenpotter.icarus.api.wings.Wing;
 import tombenpotter.icarus.common.util.IcarusWing;
@@ -16,7 +19,7 @@ import tombenpotter.icarus.common.util.cofh.StringHelper;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ItemWingAuraCascade extends ItemWing {
+public class ItemWingAuraCascade extends ItemWing implements ISpecialArmor {
 
     public static final String NBT_TIER = "Icarus_Tier";
     public static final int MAX_TIER = 11;
@@ -50,6 +53,23 @@ public class ItemWingAuraCascade extends ItemWing {
     public int getMaxDamage(ItemStack stack) {
         WingHelper.checkNBT(stack);
         return wingList.get(stack.stackTagCompound.getInteger(NBT_TIER)).durability;
+    }
+
+    @Override
+    public void damageArmor(EntityLivingBase entity, ItemStack stack, DamageSource source, int damage, int slot) {
+    }
+
+    @Override
+    public ArmorProperties getProperties(EntityLivingBase player, ItemStack armor, DamageSource source, double damage, int slot) {
+        if (source.isUnblockable()) {
+            return new ArmorProperties(0, 0, 0);
+        }
+        return new ArmorProperties(0, damageReduceAmount / 40D, armor.getMaxDamage() + 1 - armor.getItemDamage());
+    }
+
+    @Override
+    public int getArmorDisplay(EntityPlayer player, ItemStack armor, int slot) {
+        return damageReduceAmount;
     }
 
     @Override

--- a/src/main/java/tombenpotter/icarus/common/items/ItemWingThaumcraft.java
+++ b/src/main/java/tombenpotter/icarus/common/items/ItemWingThaumcraft.java
@@ -25,8 +25,8 @@ public class ItemWingThaumcraft extends ItemWing implements IRepairable {
 
         @Override
         public void onWingTick(ItemStack stack, EntityPlayer player) {
-            if (stack.getItemDamage() > 0) {
-                stack.setItemDamage(stack.getItemDamage() + 1);
+            if (stack.getItemDamage() > 0 && player.ticksExisted % 20 == 0 && player instanceof EntityPlayer) {
+                stack.setItemDamage(stack.getItemDamage() - 1);
             }
         }
 


### PR DESCRIPTION
- Fix Angel's Steel wings being damageable, by default aura cascade angel's steel tools are unbreakable so therefore things from the ingots should be as well
- Fix void metal wing repair to only activate once every second (proper void metal handling), as opposed to repairing every tick at a ridiculous speed
- Fix wing rendering to "stick" to your back while sneaking
- Removed world.isRemote in handleWingTick to fix a weird server/client desync issue with damage.
